### PR TITLE
dnsmasq.conf template: set port=0 to disable DNS on the server

### DIFF
--- a/templates/dnsmasq.conf.erb
+++ b/templates/dnsmasq.conf.erb
@@ -5,6 +5,10 @@
 except-interface=<%= @interface %>
 except-interface=tun-udp
 except-interface=tun-tcp
+
+# disable DNS on the server
+port=0
+
 dhcp-range=<%= @dhcp_range %>
 dhcp-option=6
 dhcp-lease-max=<%= @dhcp_lease_max %>


### PR DESCRIPTION
This configuration option has been taken from:

https://yulistic.gitlab.io/2018/03/configuring-dnsmasq-only-for-dhcp-server-in-ubuntu-pc/
http://lists.thekelleys.org.uk/pipermail/dnsmasq-discuss/2011q1/004687.html